### PR TITLE
Support loading ORT models as a fallback

### DIFF
--- a/src/onnx_asr/resolver.py
+++ b/src/onnx_asr/resolver.py
@@ -129,7 +129,14 @@ class Resolver(Generic[T]):
             files = list(path.glob(filename))
             if len(files) > 1:
                 raise MoreThanOneModelFileFoundError(filename, path)
-            if len(files) == 0 or not files[0].is_file():
+            if len(files) == 0:
+                orig_path = Path(filename)
+                if orig_path.suffix == ".onnx":
+                    files = list(path.glob(str(orig_path.with_suffix(".ort"))))
+                    if len(files) == 1 and files[0].is_file():
+                        return files[0]
+                raise ModelFileNotFoundError(filename, path)
+            if not files[0].is_file():
                 raise ModelFileNotFoundError(filename, path)
             return files[0]
 


### PR DESCRIPTION
This is the least disruptive option code-wise to add support for loading ORT models.