### PR TITLE
feat: add wav2vec2 CTC model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The package supports the following modern ASR model architectures. See [supporte
 * GigaChat GigaAM v2/v3/Multilingual (with CTC and RNN-T decoders, including E2E versions)
 * Kaldi Icefall Zipformer (with a stateless RNN-T decoder), including Alpha Cephei Vosk 0.52+
 * T-Tech T-one (with a CTC decoder; streaming is not yet supported)
+* HuggingFace Wav2Vec2 (with a CTC decoder)
 * OpenAI Whisper
 
 When these models are saved in ONNX format, typically only the encoder and decoder are included. Running them requires the corresponding preprocessing and decoding implementations. This package provides both for all supported models:

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -97,3 +97,81 @@ Export model to ONNX with Hugging Face `optimum-cli`:
 ```sh
 optimum-cli export onnx --model openai/whisper-base ./whisper-onnx
 ```
+
+## HuggingFace Wav2Vec2 CTC
+
+Install **transformers** and **torch**:
+
+```sh
+pip install transformers torch
+```
+
+Export the model with feature normalization (`do_normalize`) baked into the graph, so
+the model uses the plain `"identity"` preprocessor (raw waveform in, no separate
+feature-extractor asset needed):
+
+```py
+import json
+from pathlib import Path
+
+import torch
+from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
+
+hf_model_id = "proxectonos/Nos_ASR-wav2vec2-xls-r-300m-gl"
+onnx_dir = Path("wav2vec2-onnx")
+onnx_dir.mkdir(exist_ok=True)
+
+model = Wav2Vec2ForCTC.from_pretrained(hf_model_id).eval()
+processor = Wav2Vec2Processor.from_pretrained(hf_model_id)
+do_normalize = bool(processor.feature_extractor.do_normalize)
+
+
+class NormalizedWav2Vec2(torch.nn.Module):
+    def forward(self, input_values, input_lengths):
+        if do_normalize:
+            mask = torch.arange(input_values.shape[1])[None, :] < input_lengths[:, None]
+            count = input_lengths.to(input_values.dtype).clamp(min=1)[:, None]
+            mean = (input_values * mask).sum(dim=1, keepdim=True) / count
+            var = (((input_values - mean) * mask) ** 2).sum(dim=1, keepdim=True) / count
+            input_values = torch.where(mask, (input_values - mean) / torch.sqrt(var + 1e-5), input_values)
+        logits = model(input_values).logits
+        return torch.nn.functional.log_softmax(logits, dim=-1)
+
+
+torch.onnx.export(
+    NormalizedWav2Vec2(),
+    (torch.randn(1, 16000), torch.tensor([16000], dtype=torch.int64)),
+    str(onnx_dir / "model.onnx"),
+    input_names=["input_values", "input_lengths"],
+    output_names=["logprobs"],
+    dynamic_axes={
+        "input_values": {0: "batch", 1: "time"},
+        "input_lengths": {0: "batch"},
+        "logprobs": {0: "batch", 1: "frames"},
+    },
+    opset_version=18,
+)
+
+vocab = processor.tokenizer.get_vocab()
+pad_token = processor.tokenizer.pad_token
+word_delimiter = processor.tokenizer.word_delimiter_token
+
+with (onnx_dir / "vocab.txt").open("wt") as f:
+    for token, idx in sorted(vocab.items(), key=lambda kv: kv[1]):
+        token = "<blk>" if token == pad_token else "▁" if token == word_delimiter else token
+        f.write(f"{token} {idx}\n")
+
+subsampling_factor = 1
+for layer in model.wav2vec2.feature_extractor.conv_layers:
+    stride = layer.conv.stride
+    subsampling_factor *= stride[0] if isinstance(stride, tuple) else stride
+
+with (onnx_dir / "config.json").open("wt") as f:
+    json.dump({"model_type": "wav2vec2-ctc", "subsampling_factor": subsampling_factor}, f, indent=2)
+```
+
+The pad token becomes `<blk>` (CTC blank, auto-detected by the vocab loader) and the
+word-delimiter token (`|`) becomes `▁`, which onnx-asr converts to a literal space
+when decoding. `subsampling_factor` is the product of the feature-encoder conv strides
+(320 for the standard wav2vec2/XLS-R conv stack) and is only used to scale token
+timestamps.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -212,5 +212,6 @@ API reference: [onnx_asr.load_model][], [recognize][onnx_asr.adapters.AsrAdapter
 * `nemo-conformer-tdt` for NeMo Conformer/FastConformer/Parakeet with TDT decoder
 * `nemo-conformer-aed` for NeMo Canary with Transformer decoder
 * `t-one-ctc` for T-Tech T-one with CTC decoder
+* `wav2vec2-ctc` for HuggingFace Wav2Vec2 with CTC decoder (see [conversion](conversion.md#huggingface-wav2vec2-ctc))
 * `whisper-ort` for Whisper (exported with [onnxruntime](conversion.md#openai-whisper-with-onnxruntime-export))
 * `whisper` for Whisper (exported with [optimum](conversion.md#openai-whisper-with-optimum-export))

--- a/src/onnx_asr/loader.py
+++ b/src/onnx_asr/loader.py
@@ -15,6 +15,7 @@ from onnx_asr.models.nemo import NemoConformerAED, NemoConformerCtc, NemoConform
 from onnx_asr.models.pyannote import PyAnnoteVad
 from onnx_asr.models.silero import SileroVad
 from onnx_asr.models.tone import TOneCtc
+from onnx_asr.models.wav2vec2 import Wav2Vec2Ctc
 from onnx_asr.models.wespeaker import WespeakerEmbeddings
 from onnx_asr.models.whisper import WhisperHf, WhisperOrt
 from onnx_asr.onnx import OnnxSessionOptions, Provider, TensorRtOptions, get_onnx_providers, update_onnx_providers
@@ -64,6 +65,7 @@ AsrTypeNames = Literal[
     "nemo-conformer-aed",
     "t-one-ctc",
     "vosk",
+    "wav2vec2-ctc",
     "whisper-ort",
     "whisper",
 ]
@@ -83,6 +85,7 @@ AsrTypes: TypeAlias = (
     | NemoConformerRnnt
     | NemoConformerAED
     | TOneCtc
+    | Wav2Vec2Ctc
     | WhisperHf
     | WhisperOrt
 )
@@ -116,6 +119,7 @@ def create_asr_resolver(
         "nemo-conformer-aed": NemoConformerAED,
         "t-one-ctc": TOneCtc,
         "vosk": KaldiTransducer,
+        "wav2vec2-ctc": Wav2Vec2Ctc,
         "whisper-ort": WhisperOrt,
         "whisper": WhisperHf,
         "alphacep/vosk-model-ru": KaldiTransducer,
@@ -336,6 +340,7 @@ def load_model(
                 NeMo Canary (`nemo-canary-1b-v2`)
                 T-One (`t-one-ctc` | `t-tech/t-one`)
                 Vosk (`vosk` | `alphacep/vosk-model-ru` | `alphacep/vosk-model-small-ru`)
+                Wav2Vec2 CTC (`wav2vec2-ctc`)
                 Whisper Base exported with onnxruntime (`whisper-ort` | `whisper-base-ort`)
                 Whisper from onnx-community (`whisper` | `onnx-community/whisper-large-v3-turbo` |
                                              `onnx-community/*whisper*`)

--- a/src/onnx_asr/models/wav2vec2.py
+++ b/src/onnx_asr/models/wav2vec2.py
@@ -1,0 +1,51 @@
+"""Wav2Vec2 CTC model implementation."""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+import numpy.typing as npt
+import onnxruntime as rt
+
+from onnx_asr.asr import Preprocessor, _AsrWithCtcDecoding
+from onnx_asr.onnx import OnnxSessionOptions
+from onnx_asr.utils import is_float32_array, is_int64_array
+
+
+class Wav2Vec2Ctc(_AsrWithCtcDecoding):
+    """Wav2Vec2 CTC model implementation (HuggingFace wav2vec2 / XLS-R fine-tunes)."""
+
+    def __init__(  # noqa: D107
+        self,
+        model_files: dict[str, Path],
+        preprocessor_factory: Callable[[str], Preprocessor],
+        onnx_options: OnnxSessionOptions,
+    ):
+        super().__init__(model_files, preprocessor_factory, onnx_options)
+        self._model = rt.InferenceSession(model_files["model"], **onnx_options)
+
+    @staticmethod
+    def _get_model_files(quantization: str | None = None) -> dict[str, str]:
+        suffix = "?" + quantization if quantization else ""
+        return {"model": f"model{suffix}.onnx", "vocab": "vocab.txt"}
+
+    @property
+    def _preprocessor_name(self) -> str:
+        return "identity"
+
+    @property
+    def _subsampling_factor(self) -> int:
+        return int(self.config.get("subsampling_factor", 320))
+
+    def _encode(
+        self, waveforms: npt.NDArray[np.float32], waveforms_len: npt.NDArray[np.int64]
+    ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.int64]]:
+        (logprobs,) = self._model.run(
+            ["logprobs"],
+            {"input_values": waveforms, "input_lengths": waveforms_len.astype(np.int64)},
+        )
+        assert is_float32_array(logprobs)
+        out_lens = waveforms_len // self._subsampling_factor + 1
+        out_lens = np.minimum(out_lens, logprobs.shape[1]).astype(np.int64)
+        assert is_int64_array(out_lens)
+        return logprobs, out_lens


### PR DESCRIPTION
## Summary

Adds a `wav2vec2-ctc` model type for HuggingFace **Wav2Vec2 / XLS-R CTC** fine-tunes exported to ONNX.

The model reuses the existing `identity` preprocessor and CTC decoding path (as used by `t-one-ctc`): it takes a raw waveform plus input lengths and emits log-probabilities. Feature normalization (`do_normalize`) is baked into the exported graph, so no separate feature-extractor asset is needed and the raw waveform can go straight in.

converted models: https://huggingface.co/OpenVoiceOS/models?search=wav2vec

## Changes

- `src/onnx_asr/models/wav2vec2.py` — new `Wav2Vec2Ctc` (`_AsrWithCtcDecoding`); model files `model.onnx` + `vocab.txt`, `identity` preprocessor, `subsampling_factor` (default 320) for timestamp scaling.
- `src/onnx_asr/loader.py` — register `wav2vec2-ctc` in the resolver, `AsrTypeNames`, and `AsrTypes`.
- `docs/conversion.md` — conversion recipe: export with normalization folded into the graph, build `vocab.txt` (pad token → `<blk>`, word delimiter → the space marker `▁`), and derive `subsampling_factor` from the feature-encoder conv strides.
- `README.md` / `docs/usage.md` — list the new architecture and type name.

## Testing

Verified end-to-end against several converted models, e.g. `wav2vec2-base-10k-voxpopuli-ft-es` transcribing Spanish audio correctly. The exported models load via `onnx_asr.load_model(<hf-repo-id>)` and decode through the standard CTC path.