### PR TITLE
fix: translate LocalEntryNotFoundError into ModelFileNotFoundError in model resolution

### DIFF
--- a/src/onnx_asr/resolver.py
+++ b/src/onnx_asr/resolver.py
@@ -102,6 +102,7 @@ class Resolver(Generic[T]):
 
     def _download_model(self, quantization: str | None, *, local_files_only: bool) -> Path:
         from huggingface_hub import snapshot_download  # noqa: PLC0415
+        from huggingface_hub.errors import LocalEntryNotFoundError  # noqa: PLC0415
 
         files = list(self.model_type._get_model_files(quantization).values())
         files = [
@@ -116,11 +117,18 @@ class Resolver(Generic[T]):
         ]
 
         assert self.repo_id is not None
-        return Path(
-            snapshot_download(
-                self.repo_id, local_dir=self.local_dir, local_files_only=local_files_only, allow_patterns=files
-            )  # nosec
-        )
+        try:
+            return Path(
+                snapshot_download(
+                    self.repo_id, local_dir=self.local_dir, local_files_only=local_files_only, allow_patterns=files
+                )  # nosec
+            )
+        except LocalEntryNotFoundError as e:
+            # raised with local_files_only=True when files are missing from the local
+            # snapshot (also as IncompleteSnapshotError in newer huggingface_hub);
+            # translate so offline resolution reports a missing model file
+            filename = "<missing files in local snapshot>"
+            raise ModelFileNotFoundError(filename, self.repo_id) from e
 
     def _resolve_model_files(self, path: Path, quantization: str | None) -> dict[str, Path]:
         files = self.model_type._get_model_files(quantization)

--- a/tests/onnx_asr/test_resolver.py
+++ b/tests/onnx_asr/test_resolver.py
@@ -2,7 +2,9 @@ import sys
 from pathlib import Path
 from typing import get_args
 
+import huggingface_hub
 import pytest
+from huggingface_hub.errors import LocalEntryNotFoundError
 
 from onnx_asr.asr import Asr, BaseAsr
 from onnx_asr.loader import (
@@ -138,6 +140,16 @@ def test_model_file_not_found_error(tmp_path: Path) -> None:
 
 
 def test_offline_model_file_not_found_error() -> None:
+    with pytest.raises(ModelFileNotFoundError):
+        create_asr_resolver("onnx-community/whisper-tiny", offline=True).resolve_model(quantization="fp16")
+
+
+def test_offline_incomplete_snapshot_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_incomplete(*_args: object, **_kwargs: object) -> str:
+        message = "incomplete snapshot"
+        raise LocalEntryNotFoundError(message)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", raise_incomplete)
     with pytest.raises(ModelFileNotFoundError):
         create_asr_resolver("onnx-community/whisper-tiny", offline=True).resolve_model(quantization="fp16")
 


### PR DESCRIPTION
With `local_files_only=True`, `snapshot_download` raises `LocalEntryNotFoundError` — or its new subclass `IncompleteSnapshotError` in recent `huggingface_hub` — when files are missing from the local snapshot. Offline model resolution then leaks that error instead of the library's documented `ModelFileNotFoundError`.

Visible in CI as `tests/onnx_asr/test_resolver.py::test_offline_model_file_not_found_error` failing on runners whose cache holds a partial `onnx-community/whisper-tiny` snapshot — see the macos/windows 3.13/3.14 failures in #141's run (that PR does not touch this code path).

Fix: wrap the `snapshot_download` call in `_download_model` and translate the error. Catching the long-standing parent class `LocalEntryNotFoundError` needs no version checks and also covers the nothing-cached-offline case with the same consistent error type. `ModelFileNotFoundError` still subclasses `FileNotFoundError`, so the online network-retry fallback in `resolve_model` is unchanged. Includes a regression test with a monkeypatched `snapshot_download`.

Written by Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)